### PR TITLE
fix: Update Tailwind CSS configuration for PostCSS

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,13 +7,12 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
-    "autoprefixer": "^10.4.21",
     "axios": "^1.11.0",
-    "postcss": "^8.5.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
     "tailwindcss": "^4.1.12",
+    "@tailwindcss/postcss": "^0.1.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+  plugins: [
+    require('@tailwindcss/postcss'),
+    require('autoprefixer'),
+  ],
+};


### PR DESCRIPTION
This commit fixes a frontend build error caused by a change in how Tailwind CSS integrates with PostCSS.

The `tailwindcss` PostCSS plugin has been moved to a separate package, `@tailwindcss/postcss`. This commit:
- Adds `@tailwindcss/postcss` as a dependency.
- Updates `postcss.config.js` to use the new package.