### PR TITLE
fix: Update PostCSS configuration for Tailwind CSS

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  plugins: [
-    require('@tailwindcss/postcss'),
-    require('autoprefixer'),
-  ],
-};
+  plugins: {
+    '@tailwindcss/postcss': {},
+    'autoprefixer': {},
+  },
+}


### PR DESCRIPTION
This commit updates the `postcss.config.js` file to use the object syntax with the `@tailwindcss/postcss` package. This is another attempt to resolve the frontend build failure related to the PostCSS plugin for Tailwind CSS.