### PR TITLE
fix: Downgrade Tailwind CSS to v3 for CRA compatibility

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,9 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
-    "tailwindcss": "^4.1.12",
-    "@tailwindcss/postcss": "4.1.12",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.14",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
-    'autoprefixer': {},
+    tailwindcss: {},
+    autoprefixer: {},
   },
 }


### PR DESCRIPTION
This commit resolves a persistent frontend build error by downgrading Tailwind CSS from v4 to v3. `create-react-app` (v5) is not compatible with the changes introduced in Tailwind CSS v4, which caused the PostCSS plugin error.

This commit:
- Downgrades `tailwindcss` to `^3.4.1`.
- Removes the incompatible `@tailwindcss/postcss` package.
- Adds `postcss` and `autoprefixer` as explicit dependencies with versions compatible with `react-scripts@5.0.1`.
- Updates `postcss.config.js` to the format expected by Tailwind CSS v3.