### PR TITLE
fix(backend): Ensure all WSDL data is JSON serializable

### DIFF
--- a/backend/workflow.py
+++ b/backend/workflow.py
@@ -28,22 +28,22 @@ def parse_wsdl(state: GraphState) -> GraphState:
 
         parsed_data = {"services": []}
         for service in client.wsdl.services.values():
-            service_info = {"name": service.name, "ports": []}
+            service_info = {"name": str(service.name), "ports": []}
             for port in service.ports.values():
-                port_info = {"name": port.name, "binding": port.binding.name, "operations": []}
+                port_info = {"name": str(port.name), "binding": str(port.binding.name), "operations": []}
                 for operation in port.binding._operations.values():
                     input_elements = []
                     if hasattr(operation.input, 'body') and hasattr(operation.input.body, 'parts'):
                         for part in operation.input.body.parts.values():
-                            input_elements.append({"name": part.name, "type": str(part.type)})
+                            input_elements.append({"name": str(part.name), "type": str(part.type)})
 
                     output_elements = []
                     if hasattr(operation.output, 'body') and hasattr(operation.output.body, 'parts'):
                         for part in operation.output.body.parts.values():
-                            output_elements.append({"name": part.name, "type": str(part.type)})
+                            output_elements.append({"name": str(part.name), "type": str(part.type)})
 
                     operation_info = {
-                        "name": operation.name,
+                        "name": str(operation.name),
                         "input_elements": input_elements,
                         "output_elements": output_elements,
                     }


### PR DESCRIPTION
This commit resolves a `TypeError` that occurred during the generation of the LLM prompt. The WSDL parsing library (`zeep`) uses special data types like `QName` which are not serializable by the standard `json` library.

The `parse_wsdl` function has been updated to explicitly convert all data retrieved from the `zeep` client (such as service, port, operation, and part names) to strings before storing them in the application's state.

This prevents the `TypeError: Object of type QName is not JSON serializable` and allows the backend workflow to execute without crashing.