### PR TITLE
fix(backend): Enable CORS for frontend communication

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,23 @@
 from fastapi import FastAPI, UploadFile, File, Form
 from fastapi.responses import StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
 import io
 from workflow import create_workflow
 
 app = FastAPI()
+
+origins = [
+    "http://localhost:3000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 workflow = create_workflow()
 
 @app.post("/generate-soapui-project/")


### PR DESCRIPTION
This commit resolves an issue where the frontend was unable to receive responses from the backend due to browser CORS policy.

The `fastapi.middleware.cors.CORSMiddleware` has been added to the FastAPI application to allow cross-origin requests from the frontend's origin (`http://localhost:3000`). This enables the browser to accept the response from the backend and makes the application fully functional.